### PR TITLE
Additional control over cmake build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,11 @@ if(IqsMPI)
 else()
     message(STATUS "MPI functionality: disabled.")
     # Required by pybind11 to compile the Python wrapper.
+    option(IqsFPIC "" ON)
+
+endif()
+
+if(IqsFPIC)
     add_compile_options(-fPIC)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,8 @@ add_library(intel_qs STATIC
     util/utils.cpp
     util/rng_utils.cpp
 )
+target_include_directories(intel_qs INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
 # INFO: when below flag is defined, checks of the form "assert(condition)" are skipped.
 #target_compile_definitions(intel_qs NDEBUG)
 


### PR DESCRIPTION
Hi, given the new release uses a cmake build system, we have adopted this directly as a subproject in our work at ICHEC. 

One thing that tripped us was when linking against the `intel_qs` target, the include directory locations were not carried across. I have added a `target_include_directories` command to help with this (`#include "qureg/qureg.h"`  now works, without having to give paths relative to build directory, such as `#include "../qureg/qureg.h"` in the examples). I have not modified the examples to reflect this, but can do so if this is accepted as a PR.

Additionally, we make use of the fPIC option even with the MPI build, and thought it would be useful to allow this to be enabled through an option. I chose `IqsFPIC` to match conventions, but would be open to another change. 

If any changes are required, feel free to suggest.
Thanks.