### PR TITLE
Add native compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ option(IqsMPI "Enable MPI?" OFF)
 option(IqsMKL "Enable MKL?" OFF)
 option(IqsPython "Enable Python wrap?" OFF)
 option(IqsUtest "Enable unit test?" OFF)
+option(IqsNative "Enable the latest instructions?" OFF)
 
 option(BuildExamples "Build examples and tutorials?" ON)
 option(BuildInterface "Build QASM interface?" OFF)
@@ -138,6 +139,22 @@ endif()
 if(IqsFPIC)
     add_compile_options(-fPIC)
 endif()
+
+
+################################################################################
+# Enable native compilation, yes or not?
+# This option allows AVX 256 and 512 instructions to be used.
+################################################################################
+if (IqsNative)
+    if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
+        message(STATUS "Setting xhost...")
+        add_compile_options(-xhost)
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+        message(STATUS "Setting march=native...")
+        add_compile_options(-march=native)
+    endif()
+endif()
+
 
 ################################################################################
 # Locate MKL if it is already configured through Intel (mklvars.sh) scripts.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ simply set the CMake option selection to `-DIqsMPI=OFF`
 (or just omit the option selection since MPI is disabled by default in the CMake build).
 
 
+### Enable Latest Vector Instructions
+
+To compile with the latest instruction set supported by your machine, there is the option `-DIqsNative`. 
+Compiled with `-DIqsNative=ON`, the latest vector instructions (e.g. AVX512) are used if your hardware supports them. 
+By default, `-DIqsNative=OFF`.
+
+If the machine you compile and the machine you run have different architectures, 
+turning on `IqsNative` might cause problems.
+
+Underneath, this option uses [`-xhost`](https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-xhost-qxhost)
+with Intel compilers and [`-march=native`](https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html) with GNU compilers.
+
+
 ### Enable Python binding (only available without MPI)
 
 By default, whenever MPI is disabled, the building process includes the Python binding for


### PR DESCRIPTION
I added `IqsNative` option to CMake. When turned on, this option enables the latest instruction set. This is useful especially for having the latest vector instructions like AVX512.