### PR TITLE
Add extra feature related to qaoa for weighted maxcut

### DIFF
--- a/include/qaoa_features.hpp
+++ b/include/qaoa_features.hpp
@@ -21,6 +21,11 @@ namespace qaoa
   template<typename Type>
   int InitializeVectorAsMaxCutCostFunction(QubitRegister<Type> & diag,
                                            std::vector<int> & adjacency);
+
+  template<typename Type>
+  typename QubitRegister<Type>::BaseType
+  InitializeVectorAsWeightedMaxCutCostFunction(QubitRegister<Type> & diag,
+      std::vector<typename QubitRegister<Type>::BaseType> & adjacency);
   
 /////////////////////////////////////////////////////////////////////////////////////////
 // Implement the QAOA operation:

--- a/pybind11/intelqs_py.cpp
+++ b/pybind11/intelqs_py.cpp
@@ -185,6 +185,10 @@ PYBIND11_MODULE(intelqs_py, m)
           &qaoa::InitializeVectorAsMaxCutCostFunction<ComplexDP>,
           "Use IQS vector to store a large real vector and not as a quantum state.");
 
+    m.def("InitializeVectorAsWeightedMaxCutCostFunction",
+          &qaoa::InitializeVectorAsWeightedMaxCutCostFunction<ComplexDP>,
+          "Use IQS vector to store a large real vector and not as a quantum state.");
+
     m.def("ImplementQaoaLayerBasedOnCostFunction",
           &qaoa::ImplementQaoaLayerBasedOnCostFunction<ComplexDP>,
           "Implement exp(-i gamma C)|psi>.");

--- a/unit_test/import_iqs.py
+++ b/unit_test/import_iqs.py
@@ -1,0 +1,10 @@
+# Python script to test the successful import of the full stack library
+
+import sys
+sys.path.insert(0, "../build/lib/")
+import intelqs_py as iqs
+
+print("Creation of a 2-qubit state.");
+psi = iqs.QubitRegister(2, "base", 0, 0);
+
+print("The IQS library was successfully imported.")


### PR DESCRIPTION
Specifically, the function InitializeVectorAsWeightedMaxCutCostFunction()
has been added. It receives a BaseType vector as adjacency matrix instead
of the 1/0 integer vector of InitializeVectorAsMaxCutCostFunction().
Furthermore, it returns the max weight of cut edges.
The weighted case does not work well with GetHistogramFromCostFunction()
which assumes an integer max_value and transform all cut values to integers
in {0, 1, 2, ..., max_cut}.