### PR TITLE
Fix bug in chunking code for distributed controlled gates

### DIFF
--- a/benchmarks/basic_code_for_scaling.cpp
+++ b/benchmarks/basic_code_for_scaling.cpp
@@ -58,25 +58,25 @@ int main(int argc, char **argv)
   // Parse input parameters:
   for (int i = 1; i < argc; ++i)
   {
-      if (argv[i] == std::string ("-nq")) {
+      if (argv[i] == std::string ("-nq")) {		// number of qubits.
           ++i;
-          assert(i<argc);	// Unspecified number of qubits.
+          assert(i<argc);
           num_qubits = std::atoi(argv[i]);
-      } else if (argv[i] == std::string ("-ng")) {
+      } else if (argv[i] == std::string ("-ng")) {	// number of gates.
           ++i;
-          assert(i<argc);	// Unspecified number of gates.
+          assert(i<argc);
           num_gates = std::atoi(argv[i]);
-      } else if (argv[i] == std::string ("-nt")) {
+      } else if (argv[i] == std::string ("-nt")) {	// number of threads per rank.
           ++i;
-          assert(i<argc);	// Unspecified number of threads per rank.
+          assert(i<argc);
           num_threads = std::atoi(argv[i]);
-      } else if (argv[i] == std::string ("-od")) {
+      } else if (argv[i] == std::string ("-od")) {	// output directory.
           ++i;
-          assert(i<argc);	// Unspecified output directory.
+          assert(i<argc);
           out_directory = argv[i];
-      } else if (argv[i] == std::string ("-of")) {
+      } else if (argv[i] == std::string ("-of")) {	// output filename root.
           ++i;
-          assert(i<argc);	// Unspecified output filename root.
+          assert(i<argc);
           out_filename_root = argv[i];
       } else {
           std::cout << "Wrong arguments. They should be:\n"
@@ -104,7 +104,11 @@ int main(int argc, char **argv)
   G(1, 1) = {0.649564427121402, 0.373855203932477};
 
   // Initialize the qubit register and turn on specialization.
-  QubitRegister<ComplexDP> psi(num_qubits, "base", 0);
+  // Since this code may use very large number of qubits, we limit it to 2^30.
+  size_t tmp_spacesize = 0;
+  if (num_qubits>30)
+      tmp_spacesize = size_t(1L << 30);
+  QubitRegister<ComplexDP> psi(num_qubits, "base", 0, tmp_spacesize);
 if (false)  psi.TurnOnSpecialize();
   // Loop over the number of qubits and store the time elapsed in the computation.
   struct timeval time;

--- a/src/qureg_applyctrl1qubitgate.cpp
+++ b/src/qureg_applyctrl1qubitgate.cpp
@@ -81,12 +81,12 @@ double QubitRegister<Type>::HP_Distrpair(unsigned control_position, unsigned tar
   // Which chunk do we have to Send/Recv?
   // If chunk == lcl_size_half, then all chunks are needed, and if chunk=2^C it means
   // that M=C+1 and there is a special case hardcoded.
-  // If chunk > 2^(C+1), then all chunks are needed since every chunk include
+  // If chunk >= 2^(C+1), then all chunks are needed since every chunk include
   // global indices with C-bit=0,1
   // If chunk < 2^(C+1), then chunks only include global indices with either C-bit=0
   // or C-bit=1
   if ( lcl_chunk == lcl_size_half
-       || lcl_chunk >= (UL(1)<<C+1) )
+       || lcl_chunk >= (UL(1)<<(C+1)) )
   {
       for(size_t c = 0; c < lcl_size_half; c += lcl_chunk)
       {
@@ -142,7 +142,7 @@ double QubitRegister<Type>::HP_Distrpair(unsigned control_position, unsigned tar
   else
   {
       assert( lcl_chunk <= (UL(1)<<C) );
-      assert( (UL(1)<<C % lcl_chunk)==0 );
+      assert( (UL(1)<<C) % lcl_chunk==0 );
       for(size_t gc = (UL(1)<<C); gc < lcl_size_half; gc += (UL(1)<<C+1))
       for(size_t c = gc+0; c < gc+(UL(1)<<C); c += lcl_chunk)
       {

--- a/src/qureg_init.cpp
+++ b/src/qureg_init.cpp
@@ -114,11 +114,9 @@ void QubitRegister<Type>::Initialize(std::size_t new_num_qubits, std::size_t tmp
   // Sometimes it is useful to reduce the tmp_spacesize_, to be able to simulate
   // one extra qubit. The implementation of SWAP-like gates is not ready for this yet.
 
-  #if 1
   size_t hard_bound_tmp_spacesize = UL(1L << UL(30));  // 4194304 = 2^22
   if (    tmp_spacesize_ == 0		// default case
-       || local_size_ <= tmp_spacesize_	// to avoid waste of memory
-       || num_ranks_per_node <= 2 )	// extra case, probably unnecessary
+       || local_size_ <= tmp_spacesize_)	// to avoid waste of memory
   {
       // if (!myrank) printf("Setting tmp storage to half the local state size\n");
       this->tmp_spacesize_ =  lcl_size_half;
@@ -131,14 +129,6 @@ void QubitRegister<Type>::Initialize(std::size_t new_num_qubits, std::size_t tmp
   }
   else
       this->tmp_spacesize_ = hard_bound_tmp_spacesize;
-  #else
-  if (num_ranks_per_node <= 2)
-      this->tmp_spacesize_ =  lcl_size_half;
-  else
-      this->tmp_spacesize_ =  (lcl_size_half > 4194304) ? 4194304 : lcl_size_half;
-  // 4194304 = 2^22
-  assert((lcl_size_half % TmpSize()) == 0);
-  #endif
 
   this->num_qubits = new_num_qubits;
   assert(LocalSize() >= 1L);

--- a/unit_test/include/chunking_communication_test.hpp
+++ b/unit_test/include/chunking_communication_test.hpp
@@ -1,0 +1,243 @@
+#ifndef CHUNKING_COMMUNICATION_TEST_HPP
+#define CHUNKING_COMMUNICATION_TEST_HPP
+
+#include "../../include/qureg.hpp"
+
+//////////////////////////////////////////////////////////////////////////////
+// Test fixture class.
+
+class ChunkingCommunicationTest : public ::testing::Test
+{
+ protected:
+
+  ChunkingCommunicationTest()
+  { }
+
+  // just after the 'constructor'
+  void SetUp() override
+  {
+    // All tests are skipped if the rank is dummy.
+    if (qhipster::mpi::Environment::IsUsefulRank() == false)
+      GTEST_SKIP();
+
+    // All tests are skipped if the 14-qubit state is distributed in more than 2^11 ranks.
+    // In fact the MPI version needs to allocate eighth-the-local-storage for communication.
+    // If the local storage is a eight amplitudes, this cannot be further divided.
+    if (qhipster::mpi::Environment::GetStateSize() > 2048)
+      GTEST_SKIP();
+  }
+
+  const std::size_t num_qubits_ = 14;
+  double accepted_error_ = 1e-15;
+  double accepted_error_loose_ = 1e-12;
+
+  unsigned nprocs_ = qhipster::mpi::Environment::GetStateSize();
+  unsigned log2_nprocs_ = qhipster::ilog2(nprocs_);
+  size_t local_size_ = size_t(1L << size_t(num_qubits_ - log2_nprocs_));
+  size_t tmp_spacesize_half_    = local_size_/2;
+  size_t tmp_spacesize_quarter_ = local_size_/4;
+  size_t tmp_spacesize_eighth_  = local_size_/8;
+};
+
+//////////////////////////////////////////////////////////////////////////////
+// Test macros:
+
+TEST_F(ChunkingCommunicationTest, Initialization)
+{
+  // Consider 3 different sizes for the tmp_spacesize:
+  // 1/2 (default with MPI), 1/4 , 1/8 of the local_size.
+  QubitRegister<ComplexDP> psi_half    (num_qubits_, "base", 1, tmp_spacesize_half_   );
+  QubitRegister<ComplexDP> psi_quarter (num_qubits_, "base", 10200, tmp_spacesize_quarter_);
+  QubitRegister<ComplexDP> psi_eighth  (num_qubits_, "base", 5003, tmp_spacesize_eighth_ );
+
+  // Test the norm.
+  ASSERT_LE( std::abs(psi_half.ComputeNorm()-1) , accepted_error_ );
+  ASSERT_LE( std::abs(psi_quarter.ComputeNorm()-1) , accepted_error_ );
+  ASSERT_LE( std::abs(psi_eighth.ComputeNorm()-1) , accepted_error_ );
+
+  ComplexDP amplitude;
+  // Test the only non-zero entry.
+  ASSERT_DOUBLE_EQ(psi_half.GetGlobalAmplitude(1).real(), 1.);
+  ASSERT_DOUBLE_EQ(psi_quarter.GetGlobalAmplitude(10200).real(), 1.);
+  ASSERT_DOUBLE_EQ(psi_eighth.GetGlobalAmplitude(5003).real(), 1.);
+
+  // Apply gates such that |psi_half> = |+++...+>
+  psi_half.ApplyPauliX(0);
+  for (unsigned qubit=0; qubit<num_qubits_; ++qubit)
+      psi_half.ApplyHadamard(qubit);
+  // Verify overlap with a newly initialized state.
+  QubitRegister<ComplexDP> psi (num_qubits_, "++++", 0);
+  ASSERT_COMPLEX_NEAR(psi_half.ComputeOverlap(psi), ComplexDP(1,0), accepted_error_);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+TEST_F(ChunkingCommunicationTest, HadamardGate)
+{
+  // Consider 3 different sizes for the tmp_spacesize:
+  // 1/2 (default with MPI), 1/4 , 1/8 of the local_size.
+  QubitRegister<ComplexDP> psi_half    (num_qubits_, "base", 0, tmp_spacesize_half_   );
+  QubitRegister<ComplexDP> psi_quarter (num_qubits_, "base", 0, tmp_spacesize_quarter_);
+  QubitRegister<ComplexDP> psi_eighth  (num_qubits_, "base", 0, tmp_spacesize_eighth_ );
+
+  // Test the norm.
+  ASSERT_LE( std::abs(psi_half.ComputeNorm()-1) , accepted_error_ );
+  ASSERT_LE( std::abs(psi_quarter.ComputeNorm()-1) , accepted_error_ );
+  ASSERT_LE( std::abs(psi_eighth.ComputeNorm()-1) , accepted_error_ );
+
+  // Apply Hadamard on all qubits.
+  for (unsigned qubit=0; qubit<num_qubits_; ++qubit)
+  {
+      psi_half.ApplyHadamard(qubit);
+      psi_quarter.ApplyHadamard(qubit);
+      psi_eighth.ApplyHadamard(qubit);
+  }
+
+  // Verify overlap.
+  ComplexDP overlap = {1,0};
+  ASSERT_COMPLEX_NEAR(psi_half.ComputeOverlap(psi_quarter), overlap, accepted_error_);
+  ASSERT_COMPLEX_NEAR(psi_half.ComputeOverlap(psi_eighth), overlap, accepted_error_);
+  ASSERT_COMPLEX_NEAR(psi_eighth.ComputeOverlap(psi_quarter), overlap, accepted_error_);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+TEST_F(ChunkingCommunicationTest, CustomGate)
+{
+  // Consider 3 different sizes for the tmp_spacesize:
+  // 1/2 (default with MPI), 1/4 , 1/8 of the local_size.
+  QubitRegister<ComplexDP> psi_half    (num_qubits_, "base", 0, tmp_spacesize_half_   );
+  QubitRegister<ComplexDP> psi_quarter (num_qubits_, "base", 0, tmp_spacesize_quarter_);
+  QubitRegister<ComplexDP> psi_eighth  (num_qubits_, "base", 0, tmp_spacesize_eighth_ );
+
+  TM2x2<ComplexDP> G;
+  G(0, 0) = {0.592056606032915, 0.459533060553574}; 
+  G(0, 1) = {-0.314948020757856, -0.582328159830658};
+  G(1, 0) = {0.658235557641767, 0.070882241549507}; 
+  G(1, 1) = {0.649564427121402, 0.373855203932477};
+
+  // Apply custom gate on all qubits.
+  for (unsigned qubit=0; qubit<num_qubits_; ++qubit)
+  {
+      psi_half.Apply1QubitGate(qubit, G);
+      psi_quarter.Apply1QubitGate(qubit, G);
+      psi_eighth.Apply1QubitGate(qubit, G);
+  }
+
+  // Verify overlap.
+  ComplexDP overlap = {1,0};
+  ASSERT_COMPLEX_NEAR(psi_half.ComputeOverlap(psi_quarter), overlap, accepted_error_loose_);
+  ASSERT_COMPLEX_NEAR(psi_half.ComputeOverlap(psi_eighth), overlap, accepted_error_loose_);
+  ASSERT_COMPLEX_NEAR(psi_eighth.ComputeOverlap(psi_quarter), overlap, accepted_error_loose_);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+TEST_F(ChunkingCommunicationTest, CnotGate)
+{
+  // Consider 3 different sizes for the tmp_spacesize:
+  // 1/2 (default with MPI), 1/4 , 1/8 of the local_size.
+  QubitRegister<ComplexDP> psi_half    (num_qubits_, "base", 0, tmp_spacesize_half_   );
+  QubitRegister<ComplexDP> psi_quarter (num_qubits_, "base", 0, tmp_spacesize_quarter_);
+  QubitRegister<ComplexDP> psi_eighth  (num_qubits_, "base", 0, tmp_spacesize_eighth_ );
+
+  // Apply CNOT on all (ordered) qubit-pairs for the highest 6 indices.
+  for (unsigned q0=num_qubits_-6; q0<num_qubits_; ++q0)
+  for (unsigned q1=q0+1; q1<num_qubits_; ++q1)
+  {
+      psi_half.ApplyCPauliX(q0, q1);
+      psi_half.ApplyCPauliX(q1, q0);
+      psi_quarter.ApplyCPauliX(q0, q1);
+      psi_quarter.ApplyCPauliX(q1, q0);
+      psi_eighth.ApplyCPauliX(q0, q1);
+      psi_eighth.ApplyCPauliX(q1, q0);
+  }
+
+  // Verify overlap.
+  ComplexDP overlap = {1,0};
+  ASSERT_COMPLEX_NEAR(psi_half.ComputeOverlap(psi_quarter), overlap, accepted_error_);
+  ASSERT_COMPLEX_NEAR(psi_half.ComputeOverlap(psi_eighth), overlap, accepted_error_);
+  ASSERT_COMPLEX_NEAR(psi_eighth.ComputeOverlap(psi_quarter), overlap, accepted_error_);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+/*
+TEST_F(ChunkingCommunicationTest, InitializeRandomlyButSame)
+{
+  // |psi> = |00>
+  QubitRegister<ComplexDP> psi (num_qubits_,"base",0);
+  // random number generator
+  std::size_t rng_seed = 7777;
+  qhipster::RandomNumberGenerator<double> rng;
+  rng.SetSeedStreamPtrs(rng_seed);
+  psi.SetRngPtr(&rng);
+  //
+  int num_states = qhipster::mpi::Environment::GetNumStates();
+  assert (num_states==1);
+  psi.Initialize("rand",num_states);
+  // |psi> = |rand>
+
+  // Initilize the copy: |copy> = |psi>
+  QubitRegister<ComplexDP> psi_copy (psi);
+  ASSERT_DOUBLE_EQ(psi_copy.MaxAbsDiff(psi), 0 );
+  ASSERT_DOUBLE_EQ(psi_copy.MaxL2NormDiff(psi), 0 );
+  //
+  // Reinitialize |copy> by generating its amplitudes.
+  qhipster::RandomNumberGenerator<double> rng_copy;
+  rng_copy.SetSeedStreamPtrs(rng_seed);
+  psi_copy.SetRngPtr(&rng_copy);
+  psi_copy.Initialize("rand",num_states);
+  ASSERT_DOUBLE_EQ(psi_copy.MaxAbsDiff(psi), 0 );
+  ASSERT_DOUBLE_EQ(psi_copy.MaxL2NormDiff(psi), 0 );
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+TEST_F(ChunkingCommunicationTest, Hadamard)
+{
+  QubitRegister<ComplexDP> psi_0 (num_qubits_,"base",0);
+  psi_0.ApplyHadamard(0);
+  // |psi_0> = |+0> = |q0=+> x |q1=0>
+  ASSERT_NEAR( psi_0.GetProbability(0), 0.5, accepted_error_ );
+  psi_0.ApplyPauliZ(0);
+  // |psi_0> = |-0> = |q0=-> x |q1=0>
+  ASSERT_NEAR( psi_0.GetProbability(0), 0.5, accepted_error_ );
+  psi_0.ApplyHadamard(0);
+  // |psi_0> = |10> = |q0=1> x |q1=0>
+  ASSERT_NEAR( psi_0.GetProbability(0), 1. , accepted_error_ );
+
+  QubitRegister<ComplexDP> psi_1 (num_qubits_,"base",1);
+  psi_1.ApplyHadamard(0);
+  // |psi_1> = |-0> = |q0=-> x |q1=0>
+  ASSERT_NEAR( psi_1.GetProbability(0), 0.5, accepted_error_ );
+
+  QubitRegister<ComplexDP> psi_2 (num_qubits_,"base",2);
+  psi_2.ApplyHadamard(1);
+  // |psi_2> = |0-> = |q0=0> x |q1=->
+  ComplexDP amplitude = ComplexDP(1./std::sqrt(2.), 0. );
+  ASSERT_EQ(psi_2.GetGlobalAmplitude(0), amplitude);
+  ASSERT_DOUBLE_EQ(psi_2.GetGlobalAmplitude(1).real(), 0.);
+  ASSERT_EQ(psi_2.GetGlobalAmplitude(2),-amplitude);
+  ASSERT_DOUBLE_EQ(psi_2.GetGlobalAmplitude(3).imag(), 0.);
+
+  QubitRegister<ComplexDP> psi_3 (num_qubits_,"base",3);
+  psi_3.ApplyHadamard(0);
+  psi_3.ApplyHadamard(1);
+  // |psi_3> = |--> = |q0=-> x |q1=->
+  amplitude = ComplexDP(1./2., 0. );
+  ASSERT_COMPLEX_NEAR(psi_3.GetGlobalAmplitude(0),  amplitude, accepted_error_);
+  ASSERT_COMPLEX_NEAR(psi_3.GetGlobalAmplitude(1), -amplitude, accepted_error_);
+  ASSERT_COMPLEX_NEAR(psi_3.GetGlobalAmplitude(2), -amplitude, accepted_error_);
+  ASSERT_COMPLEX_NEAR(psi_3.GetGlobalAmplitude(3),  amplitude, accepted_error_);
+  // Verify that the Hadamard is self-inverse, at least on |psi_3>.
+  psi_3.ApplyHadamard(0);
+  psi_3.ApplyHadamard(1);
+  // |psi_3> = |11>
+  ASSERT_NEAR(psi_3.GetProbability(0),1, accepted_error_);
+  ASSERT_NEAR(psi_3.GetProbability(1),1, accepted_error_);
+  ASSERT_NEAR(psi_3.GetGlobalAmplitude(3).imag(), 0., accepted_error_);
+}
+*/
+//////////////////////////////////////////////////////////////////////////////
+
+#endif	// header guard CHUNKING_COMMUNICATION_TEST_HPP

--- a/unit_test/include/multiple_states_test.hpp
+++ b/unit_test/include/multiple_states_test.hpp
@@ -46,7 +46,7 @@ class MultipleStatesTest : public ::testing::Test
          qhipster::mpi::Environment::UpdateStateComm(1,false);
   }
 
-  int num_qubits_= 6;
+  int num_qubits_= 8;
   double accepted_error_ = 1e-15;
   int pool_rank_id_;
   int num_ranks_;

--- a/unit_test/suite_of_tests.cpp
+++ b/unit_test/suite_of_tests.cpp
@@ -45,6 +45,7 @@ ASSERT_NEAR(val1.imag(),val2.imag(),error);
 #include "include/gate_counter_test.hpp"
 #include "include/noisy_simulation_test.hpp"
 #include "include/extra_features_test.hpp"
+#include "include/chunking_communication_test.hpp"
 
 // These tests make sense only when MPI is enabled.
 #include "include/multiple_states_test.hpp"


### PR DESCRIPTION
A couple of assert conditions were not properly formulated and this made the chunking code fail.

In addition, when exactly 2 MPI processes were used, the chunking code was deactivated. Now this limitation has been removed.

PS: using the new pull-request flow that merge the modifications to "development" first.