### PR TITLE
fix to compile with openMPI 4 on ubuntu 20.04

### DIFF
--- a/src/qureg_init.cpp
+++ b/src/qureg_init.cpp
@@ -9,7 +9,6 @@
 #endif
 
 #include "../include/qureg.hpp"
-
 /// \addtogroup qureg
 /// @{
 
@@ -68,7 +67,7 @@ void QubitRegister<Type>::Resize(std::size_t new_num_amplitudes)
 #if defined(USE_MM_MALLOC)
   state = (Type *)_mm_malloc(nbytes, 256);
 #else
-  state_storage.Resize(num_amplitudes);
+  state_storage.resize(num_amplitudes);
   state = &state_storage[0];
 #endif
 
@@ -181,7 +180,7 @@ void QubitRegister<Type>::Allocate(std::size_t new_num_qubits, std::size_t tmp_s
 #if defined(USE_MM_MALLOC)
   state = (Type *)_mm_malloc(nbytes, 256);
 #else
-  state_storage.Resize(num_amplitudes);
+  state_storage.resize(num_amplitudes);
   state = &state_storage[0];
 #endif
 }

--- a/unit_test/mpi_env_test.cpp
+++ b/unit_test/mpi_env_test.cpp
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
 // test of the exception handling for the MPI environment
 
 #ifdef INTELQS_HAS_MPI
-  QHIPSTER_MPI_CHECK_RESULT(MPI_Errhandler_set,(MPI_COMM_WORLD, MPI_ERRORS_RETURN))
+  QHIPSTER_MPI_CHECK_RESULT(MPI_Comm_set_errhandler,(MPI_COMM_WORLD, MPI_ERRORS_RETURN))
   // test if exceptions work
   try {
     int data;


### PR DESCRIPTION
this modification removes one deprecated MPI keyword that enables to compile Intel-qs with openMPI 4.0 on ubuntu 20.04