### PR TITLE
Remove macro D(.)=double(.) since it may disrupt user's code

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This directory is used to collect all the files generated during the installatio
   mkdir build
   cd build
   CXX=g++ cmake -DIqsMPI=ON -DIqsUtest=ON -DIqsPython=ON -DBuildExamples=ON ..
-  make
+  make -j10
 ```
 The install is customizable and, above, we have chosen to use MPI, compile the
 unit tests (based on [GoogleTest framework](https://github.com/google/googletest)),

--- a/examples/quantum_fourier_transform.cpp
+++ b/examples/quantum_fourier_transform.cpp
@@ -146,11 +146,11 @@ static void cfft(iqs::QubitRegister<Type> &x)
     y[k] = {0, 0};
     for (int j = 0; j < N; j++)
     {
-      double arg = 2.0 * M_PI * D(j) * D(k) / D(N);
+      double arg = 2.0 * M_PI * double(j) * double(k) / double(N);
       Type e = Type(std::cos(arg), std::sin(arg));
       y[k] += x[j] * e;
     }
-    y[k] /= std::sqrt(D(N));
+    y[k] /= std::sqrt(double(N));
   }
 #if 0
 // Original code was:
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
   {
     using Type = ComplexSP;
 
-    if (myrank == 0) std::cout << "state initialization (single precision)\n";
+    if (myrank == 0) std::cout << "\nstate initialization (single precision)\n";
     iqs::RandomNumberGenerator<float> rng_sp;
     rng_sp.SetSeedStreamPtrs(777);
     iqs::QubitRegister<Type> psi1(num_qubits, "base", 0);
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
   {
     using Type = ComplexDP;
 
-    if (myrank == 0) std::cout << "state initialization (double precision)\n";
+    if (myrank == 0) std::cout << "\nstate initialization (double precision)\n";
     iqs::RandomNumberGenerator<double> rng_dp;
     rng_dp.SetSeedStreamPtrs(777);
     iqs::QubitRegister<Type> psi1(num_qubits, "base", 0);

--- a/include/timer.hpp
+++ b/include/timer.hpp
@@ -240,7 +240,7 @@ class Timer
     iqs::mpi::Barrier();
     double now = Wtime();
     curiter->second.total += (now - start);
-    curiter->second.flops += D(UL(1) << UL(num_qubits - 1)) * 38.0;
+    curiter->second.flops += double(UL(1) << UL(num_qubits - 1)) * 38.0;
     curiter->second.gflops = curiter->second.flops / curiter->second.total / 1e9;
   }
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -14,7 +14,6 @@
 #define INFO(x) DO_PRAGMA(message("\033[30;46mINFO\033[0m - " #x))
 #endif
 
-#define D(x) ((double)(x))
 #define UL(x) ((std::size_t)(x))
 #define sec() time_in_seconds()
 #define xstr(s) __str__(s)

--- a/src/highperfkernels.cpp
+++ b/src/highperfkernels.cpp
@@ -228,9 +228,9 @@ void Loop_SN(std::size_t start, std::size_t end, Type *state0, Type *state1,
   {
       ttot = sec() - ttmp1;
       double datab = ((state0 == state1) ? 2.0 : 4.0) * 
-                     frac_of_state_accessed * sizeof(state0[0]) * D(end - start);
+                     frac_of_state_accessed * sizeof(state0[0]) * double(end - start);
       // printf("datab=%lf len=%lu time=%lf bw=%lf\n", datab, end-start, ttot, datab / ttot / 1e9);
-      double flops = D(1L << 19) * 38.0;
+      double flops = double(1L << 19) * 38.0;
       double gflops = flops / ttot / 1e9;
       // printf("label=%s ttot = %.4lfs bw = %.2lf GB/s\n",
       //        label.c_str(), ttot, datab / ttot / 1e9);
@@ -367,8 +367,8 @@ void Loop_DN(std::size_t gstart, std::size_t gend, std::size_t pos,
   if(timer)
   {
       ttot = sec() - ttmp1;     
-      double datab = 2.0 * frac_of_state_accessed * sizeof(state0[0]) * D(gend - gstart);
-      double flops = D(1L << 19) * 38.0;
+      double datab = 2.0 * frac_of_state_accessed * sizeof(state0[0]) * double(gend - gstart);
+      double flops = double(1L << 19) * 38.0;
       double gflops = flops / ttot / 1e9;
       // printf("label=%s ttot = %.4lfs bw = %.2lf GB/s\n",
       //         label.c_str(), ttot, datab / ttot / 1e9);
@@ -476,8 +476,8 @@ void Loop_TN(Type *state,
   {
     ttot = sec() - ttmp1;
     double datab =
-      4.0 * sizeof(state[0]) * D((c12 - c11) / c13) * D((c22 - c21) / c23) * D(c32 - c31);
-    double flops = D(1L << 19) * 38.0;
+      4.0 * sizeof(state[0]) * double((c12 - c11) / c13) * double((c22 - c21) / c23) * double(c32 - c31);
+    double flops = double(1L << 19) * 38.0;
     double gflops = flops / ttot / 1e9;
     // printf("label=%s ttot = %.4lfs bw = %.2lf GB/s\n",
     //        "ScaleState", ttot, datab / ttot / 1e9);
@@ -509,8 +509,8 @@ void ScaleState(std::size_t start, std::size_t end, Type *state,
   }
   if (timer) {
     ttot = sec() - ttmp1;
-    double datab = 2.0 * sizeof(state[0]) * D(end - start);
-    double flops = D(1L << 19) * 38.0;
+    double datab = 2.0 * sizeof(state[0]) * double(end - start);
+    double flops = double(1L << 19) * 38.0;
     double gflops = flops / ttot / 1e9;
     // printf("label=%s ttot = %.4lfs bw = %.2lf GB/s\n",
     //        "ScaleState", ttot, datab / ttot / 1e9);

--- a/src/qureg_apply1qubitgate.cpp
+++ b/src/qureg_apply1qubitgate.cpp
@@ -159,7 +159,7 @@ double QubitRegister<Type>::HP_Distrpair(unsigned position, TM2x2<Type> const&m,
     }
   }
 
-  double netsize = 2.0 * sizeof(Type) * 2.0 * D(lcl_size_half), netbw = netsize / tnet;
+  double netsize = 2.0 * sizeof(Type) * 2.0 * double(lcl_size_half), netbw = netsize / tnet;
   // printf("[%3d] size=%10lld tnet = %.3lf s netsize = %10.0lf bytes netbw = %6.2lf GB/s\n",
   //      it, sizeof(Type)*lcl_size_half, tnet, netsize, netbw / 1e9);
 

--- a/src/qureg_applyctrl1qubitgate.cpp
+++ b/src/qureg_applyctrl1qubitgate.cpp
@@ -212,7 +212,7 @@ double QubitRegister<Type>::HP_Distrpair(unsigned control_position, unsigned tar
       }
   }
 
-  double netsize = 2.0 * sizeof(Type) * 2.0 * D(lcl_size_half), netbw = netsize / tnet;
+  double netsize = 2.0 * sizeof(Type) * 2.0 * double(lcl_size_half), netbw = netsize / tnet;
   if (timer) timer->record_cm(tnet, netbw);
 #endif
 

--- a/src/qureg_applyswap.cpp
+++ b/src/qureg_applyswap.cpp
@@ -472,7 +472,7 @@ double QubitRegister<Type>::HP_DistrSwap(unsigned low_position, unsigned high_po
         }
   }
 
-  double netsize = 2.0 * sizeof(Type) * 2.0 * D(lcl_size_half), netbw = netsize / tnet;
+  double netsize = 2.0 * sizeof(Type) * 2.0 * double(lcl_size_half), netbw = netsize / tnet;
   if (timer) timer->record_cm(tnet, netbw);
 #endif
 

--- a/src/qureg_init.cpp
+++ b/src/qureg_init.cpp
@@ -168,13 +168,13 @@ void QubitRegister<Type>::Allocate(std::size_t new_num_qubits, std::size_t tmp_s
   {
       double MB = 1024.0 * 1024.0;
       double s;
-      s = D(num_ranks_per_node) * D(nbytes);
+      s = double(num_ranks_per_node) * double(nbytes);
       printf("Total storage per node  = %.2lf MB \n", s / MB);
-      s = D(num_ranks_per_node) * D(LocalSize()) * D(sizeof(state[0]));
+      s = double(num_ranks_per_node) * double(LocalSize()) * double(sizeof(state[0]));
       printf("      storage per state = %.2lf MB \n", s / MB);
       if (nprocs > 1)
       {
-          s = D(num_ranks_per_node) * D(TmpSize()) * D(sizeof(state[0]));
+          s = double(num_ranks_per_node) * double(TmpSize()) * double(sizeof(state[0]));
           printf("      temporary storage = %.5lf MB \n", s / MB);
       }
   }

--- a/src/qureg_utils.cpp
+++ b/src/qureg_utils.cpp
@@ -282,7 +282,7 @@ double QubitRegister<Type>::Entropy()
  
   if (timer)
   {
-      double datab = D(sizeof(state[0])) * D(lcl) / ttot;
+      double datab = double(sizeof(state[0])) * double(lcl) / ttot;
       timer->record_sn(ttot, datab / ttot);
       timer->Stop();
   }
@@ -299,7 +299,7 @@ std::vector<double> QubitRegister<Type>::GoogleStats()
   std::vector <double> stats;
 
   std::size_t lcl = LocalSize();
-  double two2n = D(GlobalSize());
+  double two2n = double(GlobalSize());
   
   double entropy = 0, avgselfinfo=0,
          m2 = 0, m3 = 0, m4 = 0, m5 = 0, m6 = 0, 
@@ -370,8 +370,8 @@ std::vector<double> QubitRegister<Type>::GoogleStats()
   for(auto i = 0; i < m.size(); i++)
   {
       auto k = i + 2;
-      factorial *= D(k);
-      factor[i] = pow(two2n, D(k - 1)) / factorial;
+      factorial *= double(k);
+      factor[i] = pow(two2n, double(k - 1)) / factorial;
 
       m[i] *= factor[i];
 #ifdef INTELQS_HAS_MPI
@@ -386,7 +386,7 @@ std::vector<double> QubitRegister<Type>::GoogleStats()
 
   if (timer)
   {
-      double datab = D(sizeof(state[0])) * D(lcl) / ttot;
+      double datab = double(sizeof(state[0])) * double(lcl) / ttot;
       timer->record_sn(ttot, datab / ttot);
       timer->Stop();
   }
@@ -625,7 +625,7 @@ void QubitRegister<Type>::dumpbin(std::string fn)
   MPI_File_close(&fh);
   if (myrank == 0)
   {
-      double bw = D(UL(sizeof(state[0])) * size) / (t1 - t0) / 1e6;
+      double bw = double(UL(sizeof(state[0])) * size) / (t1 - t0) / 1e6;
       printf("Dumping state to %s took %lf sec (%lf MB/s)\n", (const char *)fn.c_str(), (double)(t1 - t0), (double)bw);
   }
 #else

--- a/src/spec_kernels.cpp
+++ b/src/spec_kernels.cpp
@@ -236,9 +236,9 @@ void Loop_SN(std::size_t gstart, std::size_t gend,
   {
     ttot = sec() - ttmp1;
     double datab = ((state0 == state1) ? 2.0 : 4.0) *
-        sizeof(state0[0]) * D(gend - gstart);
+        sizeof(state0[0]) * double(gend - gstart);
     
-    double flops = D(1L << 19) * 38.0;
+    double flops = double(1L << 19) * 38.0;
     double gflops = flops / ttot / 1e9;
 
     timer->record_sn(ttot, datab / ttot);
@@ -326,7 +326,7 @@ void Loop_DN(std::size_t gstart, std::size_t gend, std::size_t pos,
  if(timer)
   {
       ttot = sec() - ttmp1;     
-      double datab = 2.0 * sizeof(state0[0]) * D(gend - gstart);
+      double datab = 2.0 * sizeof(state0[0]) * double(gend - gstart);
       timer->record_dn(ttot, datab / ttot);
   }
 }
@@ -411,7 +411,7 @@ void Loop_TN(Type *state,
   {
     ttot = sec() - ttmp1;
     double datab =
-      4.0 * sizeof(state[0]) * D((c12 - c11) / c13) * D((c22 - c21) / c23) * D(c32 - c31);
+      4.0 * sizeof(state[0]) * double((c12 - c11) / c13) * double((c22 - c21) / c23) * double(c32 - c31);
     timer->record_tn(ttot, datab / ttot);
   }
 }

--- a/unit_test/include/permutation_test.hpp
+++ b/unit_test/include/permutation_test.hpp
@@ -288,7 +288,7 @@ namespace utest
     {
         state.resize(1 << p.num_elements);
         for (std::size_t i = 0; i < state.size(); i++)
-            state[i] = {D(i % 3), D(i % 16)};
+            state[i] = {double(i % 3), double(i % 16)};
     }
  
     // Permute the order of the entries according to the Permutation pnew.
@@ -324,8 +324,8 @@ namespace utest
         }
         std::uint64_t t1 = __rdtsc();
         double s1 = iqs::sec();
-        double bw = D(state.size()) * D(sizeof(state[0])) * 2.0 / D(s1 - s0);
-        if (do_print) printf("cycles per shuffle: %.2lf bw=%.2lf GB/s\n", D(t1 - t0) / D(state.size()), bw / 1e9);
+        double bw = double(state.size()) * double(sizeof(state[0])) * 2.0 / double(s1 - s0);
+        if (do_print) printf("cycles per shuffle: %.2lf bw=%.2lf GB/s\n", double(t1 - t0) / double(state.size()), bw / 1e9);
     
         p = pnew;
         state = state_new;


### PR DESCRIPTION
The reason is that users may have variables named 'D' as is the case, for example, for the widespread optimization library called dlib.