### PR TITLE
Eigen as optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option(IqsMPI "Enable MPI?" OFF)
 option(IqsMKL "Enable MKL?" OFF)
 option(IqsPython "Enable Python wrap?" OFF)
 option(IqsUtest "Enable unit test?" OFF)
+option(IqsNoise "Enable stochastic simulation of noise channels?" OFF)
 option(BuildExamples "Build the Examples" OFF)
 option(BuildInterface "Build the QASM Interface" OFF)
 option(IqsNative "Enable the latest vector instructions?" OFF)
@@ -130,6 +131,7 @@ endif()
 # Enable native compilation, yes or not?
 # This option allows AVX 256 and 512 instructions to be used.
 ################################################################################
+
 if (IqsNative)
     if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
         message(STATUS "Setting xhost...")
@@ -144,6 +146,7 @@ endif()
 ################################################################################
 # Enable compiler optimizations to fix GCC performance.
 ################################################################################
+
 if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
    add_compile_options(-O3)
 endif()
@@ -282,6 +285,10 @@ add_compile_definitions(USE_MM_MALLOC)
 # library archive. Also, place the archive in the lib subdir. 
 ################################################################################
 
+if(IqsNoise)
+    add_compile_definitions(IQS_WITH_NOISE)
+endif()
+
 add_subdirectory(src)
 
 if(BuildExamples)
@@ -336,6 +343,7 @@ STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsMKL    = " ${Iq
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsMPI    = " ${IqsMPI} "\n")
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsUtest  = " ${IqsUtest} "\n")
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsPython = " ${IqsPython} "\n")
+STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsNoise  = " ${IqsNoise} "\n")
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsNative = " ${IqsNative} "\n\n")
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "BuildExamples  = " ${BuildExamples} "\n")
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "BuildInterface = " ${BuildInterface})

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following packages are required by the installation:
 *  optional: MKL for distributed random number generation
 *  optional: PyBind11 (installed via conda, not pip) required by the Python binding of Intel-QS
 *  optional: GoogleTest (automatically installed if needed during the build) required by the unit tests
+*  optional: Eigen (library to solve eigensystems) required for simulations with realistic noise
 
 The first step is cloning the repository:
 ```bash
@@ -67,12 +68,14 @@ This directory is used to collect all the files generated during the installatio
 ```bash
   mkdir build
   cd build
-  CXX=g++ cmake -DIqsMPI=ON -DIqsUtest=ON -DIqsPython=ON -DBuildExamples=ON ..
+  CXX=g++ cmake -DIqsMPI=ON -DIqsUtest=ON -DIqsPython=ON -DIqsNoise=OFF -DBuildExamples=ON ..
   make -j10
 ```
 The install is customizable and, above, we have chosen to use MPI, compile the
 unit tests (based on [GoogleTest framework](https://github.com/google/googletest)),
 create a Python library via [PyBind11](https://github.com/pybind/pybind11),
+not include the possibility of simulating noisiy gates as quantum channels
+(feature that would need library [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page)),
 and compile a set of C++ examples.
 
 To re-build Intel-QS with different settings or options, we recommend to delete all content of the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,22 +2,20 @@
 # Construction of IQS as a shared library
 ################################################################################
 
-#message(STATUS "Source dir ${PROJECT_SOURCE_DIR} , while modules are in ${CMAKE_MODULE_PATH}")
-#message(STATUS "Binary dir ${CMAKE_BINARY_DIR} , and project_bin ${CMAKE_CURRENT_BINARY_DIR}")
-
-# Download and unpack eigen library at configure time.
-cmake_minimum_required(VERSION 3.12.0)
-include(../cmake/ExternalProject.cmake)
-ExternalProject_Add(deps-eigen
-  GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-  PREFIX            "${CMAKE_BINARY_DIR}/deps/eigen-prefix/"
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
-  GIT_SHALLOW 1
-)
-
-message(STATUS "Eigen library is downloaded in: ${PROJECT_BINARY_DIR}/deps/eigen-prefix/src/eigen/")
+if (IqsNoise)
+    # Download and unpack eigen library at configure time.
+    cmake_minimum_required(VERSION 3.12.0)
+    include(../cmake/ExternalProject.cmake)
+    ExternalProject_Add(deps-eigen
+      GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+      PREFIX            "${CMAKE_BINARY_DIR}/deps/eigen-prefix/"
+      CONFIGURE_COMMAND ""
+      BUILD_COMMAND     ""
+      INSTALL_COMMAND   ""
+      GIT_SHALLOW 1
+    )
+    message(STATUS "Eigen library is downloaded in: ${PROJECT_BINARY_DIR}/deps/eigen-prefix/src/eigen/")
+endif()
 
 ################################################################################
 
@@ -49,15 +47,16 @@ set(IQS_FILES
 
 add_library(iqs SHARED ${IQS_FILES})
 
-add_dependencies(iqs deps-eigen)
-
 target_include_directories(iqs PUBLIC ../include)
-target_include_directories(iqs PUBLIC ${CMAKE_BINARY_DIR}/deps/eigen-prefix/src/deps-eigen/Eigen)
 target_include_directories(iqs INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 
-# When using ICC, there is a verbose warning from the external library 'eigen'. Disable the warning:
-if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
-    target_compile_options(iqs PUBLIC -wd2196)
+if (IqsNoise)
+    add_dependencies(iqs deps-eigen)
+    target_include_directories(iqs PUBLIC ${CMAKE_BINARY_DIR}/deps/eigen-prefix/src/deps-eigen/Eigen)
+    # When using ICC, there is a verbose warning from the external library 'eigen'. Disable the warning:
+    if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
+        target_compile_options(iqs PUBLIC -wd2196)
+    endif()
 endif()
 
 set_target_properties(iqs

--- a/src/chi_matrix.cpp
+++ b/src/chi_matrix.cpp
@@ -9,7 +9,9 @@
 
 #include <typeinfo>
 
+#ifdef IQS_WITH_NOISE
 #include "Dense"  // Eigen
+#endif
 
 #include "tinymatrix.hpp"
 #include "utils.hpp"
@@ -63,6 +65,9 @@ namespace iqs {
   template <class ValueType, unsigned M, unsigned align>
   void ChiMatrix<ValueType, M, align>::SolveEigenSystem()
   {
+#ifndef IQS_WITH_NOISE
+    assert(0 && "Error: method ChiMatrix::EigensystemOfIdealHadamardChannel called in noiseless simulations.");
+#else
     // Initialize
     evalues_.assign(M, 0);
     evectors_.assign(M, evalues_);
@@ -120,6 +125,7 @@ namespace iqs {
 
     // Normalize the probabilities and renormalize the eigenvectors.
     this->NormalizeEigenProbAndRenormalizeEigenVect();
+#endif
   }
  
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/unit_test/include/apply_1q_gate_test.hpp
+++ b/unit_test/include/apply_1q_gate_test.hpp
@@ -24,7 +24,7 @@ class Apply1QGateTest : public ::testing::Test
     // In fact the MPI version needs to allocate half-the-local-storage for communication.
     // If the local storage is a single amplitude, this cannot be further divided.
     if (iqs::mpi::Environment::GetStateSize() > 8)
-        GTEST_SKIP();
+        GTEST_SKIP() << "INFO: small state distributed among too many ranks.";
 
     std::cout << "state_rank_id = " << iqs::mpi::Environment::GetStateRank() << "\n";//FIXME delete
     iqs::mpi::StateBarrier();

--- a/unit_test/include/apply_swap_gate_test.hpp
+++ b/unit_test/include/apply_swap_gate_test.hpp
@@ -24,7 +24,7 @@ class ApplySwapGateTest : public ::testing::Test
     // In fact the MPI version needs to allocate half-the-local-storage for communication.
     // If the local storage is a single amplitude, this cannot be further divided.
     if (iqs::mpi::Environment::GetStateSize() > 512)
-        GTEST_SKIP();
+        GTEST_SKIP() << "INFO: small state distributed among too many ranks.";
   }
 
   const std::size_t num_qubits_ = 10;

--- a/unit_test/include/chi_matrix_test.hpp
+++ b/unit_test/include/chi_matrix_test.hpp
@@ -136,6 +136,9 @@ void chimatrix_testassign()
 template <class T>
 void chimatrix_testeigen()
 {
+#ifndef IQS_WITH_NOISE
+  GTEST_SKIP() << "INFO: Library Eigen is not used for noiseless simulations";
+#else
   iqs::ChiMatrix<T, 2> chimat2 = {{T(1.), T(3.)}, {T(3.), T(7.)}};
   
   chimat2.SolveEigenSystem();
@@ -165,7 +168,7 @@ void chimatrix_testeigen()
   This eigenvectors are already standardized, but one still needs to normalize them:
   (normalized) Eigenvectors: [-2.69121547  1.11473795]  and  [-1.11473795 -2.69121547] 
   */
-
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/unit_test/include/chunking_communication_test.hpp
+++ b/unit_test/include/chunking_communication_test.hpp
@@ -24,7 +24,7 @@ class ChunkingCommunicationTest : public ::testing::Test
     // In fact the MPI version needs to allocate eighth-the-local-storage for communication.
     // If the local storage is a eight amplitudes, this cannot be further divided.
     if (iqs::mpi::Environment::GetStateSize() > 2048)
-      GTEST_SKIP();
+      GTEST_SKIP() << "INFO: small state distributed among too many ranks.";
   }
 
   const std::size_t num_qubits_ = 14;

--- a/unit_test/include/compiler_flags_test.hpp
+++ b/unit_test/include/compiler_flags_test.hpp
@@ -36,6 +36,12 @@ TEST_F(CompileFlagTest, AllFlags)
     std::cout << "             |            INTELQS_HAS_MPI |          |\n";
 #endif
 //
+#ifdef IQS_WITH_NOISE
+    std::cout << "             |             IQS_WITH_NOISE |    X     |\n";
+#else
+    std::cout << "             |             IQS_WITH_NOISE |          |\n";
+#endif
+//
 #ifdef USE_MKL
     std::cout << "             |                    USE_MKL |    X     |\n";
 #else

--- a/unit_test/include/expectation_values_test.hpp
+++ b/unit_test/include/expectation_values_test.hpp
@@ -22,7 +22,7 @@ class ExpectationValuesTest : public ::testing::Test
 
     // All tests are skipped if the 4-qubit state is distributed in more than 8 ranks.
     if (iqs::mpi::Environment::GetStateSize() > 8)
-      GTEST_SKIP();
+      GTEST_SKIP() << "INFO: small state distributed among too many ranks.";
   }
 
   const std::size_t num_qubits_ = 6;

--- a/unit_test/include/gate_counter_test.hpp
+++ b/unit_test/include/gate_counter_test.hpp
@@ -134,7 +134,7 @@ TEST_F(GateCounterTest, CustomTwoQubitGates)
 {
   // Arbitrary two-qubit gates are implemented only when StateSize=1.
   if (iqs::mpi::Environment::GetStateSize() > 1)
-      GTEST_SKIP();
+      GTEST_SKIP() << "INFO: arbitrary 2-qubit gates require non-distributed states.";
 
   int expected_counter = 0;
   // |psi> = |1010010000> = |"1+4+32">
@@ -149,7 +149,7 @@ TEST_F(GateCounterTest, CustomTwoQubitGates)
 
 TEST_F(GateCounterTest, ToffoliGate)
 {
-  GTEST_SKIP(); // FIXME: to check if action error comes from memory limits
+  GTEST_SKIP() << "INFO: ToffoliGate is a test under development."; // FIXME: to check if action error comes from memory limits
   // |psi> = |0000000000> = |"0">
   std::cout << "Checkpoint A\n"; // FIXME: to check origin of github action error
   iqs::QubitRegister<ComplexDP> psi (num_qubits_,"base",0);

--- a/unit_test/include/measure_test.hpp
+++ b/unit_test/include/measure_test.hpp
@@ -24,7 +24,7 @@ class MeasureTest : public ::testing::Test
 
     // All tests are skipped if the 4-qubit state is distributed in more than 8 ranks.
     if (iqs::mpi::Environment::GetStateSize() > 8)
-      GTEST_SKIP();
+      GTEST_SKIP() << "INFO: small state distributed among too many ranks.";
   }
 
   const std::size_t num_qubits_ = 4;

--- a/unit_test/include/multiple_states_test.hpp
+++ b/unit_test/include/multiple_states_test.hpp
@@ -36,7 +36,7 @@ class MultipleStatesTest : public ::testing::Test
   {
     // This kind of tests makes no sense without MPI and at least 2 ranks.
     if (num_ranks_<2)
-        GTEST_SKIP();
+        GTEST_SKIP() << "INFO: test is meaningful only if at least 2 ranks are used.";
   }
 
   // Just before the 'destructor'.

--- a/unit_test/include/noisy_simulation_test.hpp
+++ b/unit_test/include/noisy_simulation_test.hpp
@@ -35,7 +35,7 @@ class NoisySimulationTest : public ::testing::Test
   {
       // This kind of tests makes no sense without MPI and at least 2 ranks.
       if (num_ranks_<2)
-          GTEST_SKIP();
+          GTEST_SKIP() << "INFO: test requires at least 2 ranks to be meaningful.";
   }
 
   // Just before the 'destructor'.

--- a/unit_test/include/qaoa_features_test.hpp
+++ b/unit_test/include/qaoa_features_test.hpp
@@ -25,7 +25,7 @@ class QaoaFeaturestest : public ::testing::Test
     // In fact the MPI version needs to allocate half-the-local-storage for communication.
     // If the local storage is a single amplitude, this cannot be further divided.
     if (iqs::mpi::Environment::GetStateSize() > 32)
-        GTEST_SKIP();
+        GTEST_SKIP() << "INFO: small state distributed among too many ranks.";
   }
 
   const std::size_t num_qubits_ = 6;

--- a/unit_test/include/qureg_apply_channel.hpp
+++ b/unit_test/include/qureg_apply_channel.hpp
@@ -70,6 +70,9 @@ TEST_F(ApplyQuantumChannel, IdealHadamard)
 //    rho' = (1-p) rho + p/3 ( X.rho.X + Y.rho.Y + Z.rho.Z )
 TEST_F(ApplyQuantumChannel, DepolarizingChannel)
 {
+#ifndef IQS_WITH_NOISE
+  GTEST_SKIP() << "INFO: Library Eigen is not used for noiseless simulations";
+#else
   double p = 0.01;
   CM4x4<ComplexDP> chi;
   for (int i=0; i<4; ++i)
@@ -118,6 +121,7 @@ TEST_F(ApplyQuantumChannel, DepolarizingChannel)
                     << overlap_squared[t]/double(num_ensemble_states) << "\n";
       }
   }
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/unit_test/include/qureg_permute_test.hpp
+++ b/unit_test/include/qureg_permute_test.hpp
@@ -80,7 +80,7 @@ TEST_F(QuregPermuteTest, PermuteLocalQubits)
   //       |--|     |--------|            |-------|
   map_  = {1, 0, 2, 6, 4, 5, 3, 7, 8, 9, 12, 11, 10, 13, 14, 15, 16, 17, 18, 19};
   if (12 > M_)
-      GTEST_SKIP();
+      GTEST_SKIP() << "INFO: number of local qubits should be larger than 12.";
   else
   {
       psi.PermuteLocalQubits(map_, "direct");

--- a/unit_test/include/single_qubit_gates_test.hpp
+++ b/unit_test/include/single_qubit_gates_test.hpp
@@ -24,7 +24,7 @@ class SingleQubitGatesTest : public ::testing::Test
     // In fact the MPI version needs to allocate half-the-local-storage for communication.
     // If the local storage is a single amplitude, this cannot be further divided.
     if (iqs::mpi::Environment::GetStateSize() > 511)
-        GTEST_SKIP();
+        GTEST_SKIP() << "INFO: small state distributed among too many ranks.";
 
     G_(0, 0) = {0.592056606032915, 0.459533060553574}; 
     G_(0, 1) = {-0.314948020757856, -0.582328159830658};
@@ -125,7 +125,7 @@ TEST_F(SingleQubitGatesTest, DeathTest)
 {
   // Skip death-tests if compiler flag NDEBUG is defined.
 #ifdef NDEBUG
-  GTEST_SKIP();
+  GTEST_SKIP() << "INFO: test skipped when compiler flag NDEBUG is not defined.";
 #endif
 
   // Skip death-tests if MPI size > 1.

--- a/unit_test/include/state_initialization_test.hpp
+++ b/unit_test/include/state_initialization_test.hpp
@@ -22,7 +22,7 @@ class StateInitializationTest : public ::testing::Test
 
     // All tests are skipped if the 10-qubit state is distributed in more than 512 ranks.
     if (iqs::mpi::Environment::GetStateSize() > 512)
-      GTEST_SKIP();
+      GTEST_SKIP() << "INFO: small state distributed among too many ranks.";
 
     G_(0, 0) = {0.592056606032915, 0.459533060553574}; 
     G_(0, 1) = {-0.314948020757856, -0.582328159830658};
@@ -253,7 +253,7 @@ TEST_F(StateInitializationTest, DeathTest)
 {
   // Skip death-tests if compiler flag NDEBUG is defined.
 #ifdef NDEBUG
-  GTEST_SKIP();
+  GTEST_SKIP() << "INFO: test is skipped when compiler flag NDEBUG is not defined.";
 #endif
 
   // Skip death-tests if MPI size > 1.

--- a/unit_test/include/two_qubit_register_test.hpp
+++ b/unit_test/include/two_qubit_register_test.hpp
@@ -24,7 +24,7 @@ class TwoQubitRegisterTest : public ::testing::Test
     // In fact the MPI version needs to allocate half-the-local-storage for communication.
     // If the local storage is a single amplitude, this cannot be further divided.
     if (iqs::mpi::Environment::GetStateSize() > 2)
-      GTEST_SKIP();
+      GTEST_SKIP() << "INFO: small state distributed among too many ranks.";
   }
 
   const std::size_t num_qubits_ = 2;

--- a/unit_test/include/utility_methods_test.hpp
+++ b/unit_test/include/utility_methods_test.hpp
@@ -22,7 +22,7 @@ class UtilityMethodsTest : public ::testing::Test
 
     // All tests are skipped if the 4-qubit state is distributed in more than 2^3 ranks.
     if (iqs::mpi::Environment::GetStateSize() > 8)
-      GTEST_SKIP();
+      GTEST_SKIP() << "INFO: small state distributed among too many ranks.";
   }
 
   const std::size_t num_qubits_ = 4;


### PR DESCRIPTION
Intel Quantum Simulator has two ways of simulating noise.
The first one, discussed for example in [https://arxiv.org/abs/1602.01857](https://arxiv.org/abs/1602.01857), is based on "noise gates". The second one, part of a work-in-progress article, is based on representing noisy gates as quantum channels.
The latter uses library [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) to solve eigensystems of matrices.

Eigen is currently downloaded and used by the default CMake building process. This increases compile time and exposes Intel QS to disruption when Eigen's repo is down. This pull request fix the issues by including Eigen as optional. To enable the "quantum channel" feature, the CMake option `-DIqsNoise=ON` should be set. 