### PR TITLE
Add option to build as static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option(IqsUtest "Enable unit test?" OFF)
 option(BuildExamples "Build the Examples" OFF)
 option(BuildInterface "Build the QASM Interface" OFF)
 option(IqsNative "Enable the latest vector instructions?" OFF)
+option(IqsBuildAsStatic "Build IQS as a static library?" OFF)
 
 ################################################################################
 # Enable MPI, yes or not?
@@ -336,7 +337,8 @@ STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsMKL    = " ${Iq
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsMPI    = " ${IqsMPI} "\n")
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsUtest  = " ${IqsUtest} "\n")
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsPython = " ${IqsPython} "\n")
-STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsNative = " ${IqsNative} "\n\n")
+STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsNative = " ${IqsNative} "\n")
+STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "IqsBuildAsStatic = " ${IqsBuildAsStatic} "\n\n")
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "BuildExamples  = " ${BuildExamples} "\n")
 STRING(CONCAT CONFIG_STATUS_CONTENT ${CONFIG_STATUS_CONTENT} "BuildInterface = " ${BuildInterface})
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/config.status ${CONFIG_STATUS_CONTENT} )

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ The complete guide to the installation can be found in
 
 At the end of the installation, the library object will be: `/builb/lib/libiqs.so`
 
+### Build Options
+
+The following are build options in cmake:
+
+* IqsMPI : Enables MPI
+* IqsMKL : Enables MKL
+* IqsPython : Enables Python wrapper
+* IqsUtest : Builds unit tests
+* IqsNative : Enables the latest vector instructions to be built in the build
+* IqsBuildAsStatic : Builds IQS as a static library instead of a shared library
+* BuildExamples : Builds the examples 
+* BuildInterface : Builds the QASM Interface
+
 
 ### Requirements
 

--- a/cmake/gtest.cmake.in
+++ b/cmake/gtest.cmake.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,11 @@ set(IQS_FILES
   gate_spec.cpp
   CACHE INTERNAL "" FORCE)
 
-add_library(iqs SHARED ${IQS_FILES})
+if(BUILD_STATIC)
+  add_library(iqs STATIC ${IQS_FILES})
+else()
+  add_library(iqs SHARED ${IQS_FILES})
+endif()
 
 add_dependencies(iqs deps-eigen)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,7 @@ set(IQS_FILES
   gate_spec.cpp
   CACHE INTERNAL "" FORCE)
 
-if(BUILD_STATIC)
+if(IqsBuildAsStatic)
   add_library(iqs STATIC ${IQS_FILES})
 else()
   add_library(iqs SHARED ${IQS_FILES})


### PR DESCRIPTION
Add option to build iqs as a static library.
If built by default, it builds as a shared library. If build via cmake -DBUILD_STATIC=ON .. it builds as a static library.