### PR TITLE
Switch to C++ complex MPI types

### DIFF
--- a/include/mpi_utils.hpp
+++ b/include/mpi_utils.hpp
@@ -50,8 +50,8 @@ int MPI_Sendrecv_x(ComplexSP *sendbuf, size_t sendcount, size_t dest, size_t sen
                    ComplexSP *recvbuf, size_t recvcount, size_t source, size_t recvtag,
                    MPI_Comm comm, MPI_Status *status)
 {
-  return MPI_Sendrecv((void *)sendbuf, sendcount, MPI_COMPLEX, dest, sendtag,
-                      (void *)recvbuf, recvcount, MPI_COMPLEX, source, recvtag,
+  return MPI_Sendrecv((void *)sendbuf, sendcount, MPI_CXX_FLOAT_COMPLEX, dest, sendtag,
+                      (void *)recvbuf, recvcount, MPI_CXX_FLOAT_COMPLEX, source, recvtag,
                        comm, status);
 }
 
@@ -60,8 +60,8 @@ int MPI_Sendrecv_x(ComplexDP *sendbuf, size_t sendcount, size_t dest, size_t sen
                    ComplexDP *recvbuf, size_t recvcount, size_t source, size_t recvtag,
                    MPI_Comm comm, MPI_Status *status)
 {
-  return MPI_Sendrecv((void *)sendbuf, sendcount, MPI_DOUBLE_COMPLEX, dest, sendtag,
-                      (void *)recvbuf, recvcount, MPI_DOUBLE_COMPLEX, source, recvtag,
+  return MPI_Sendrecv((void *)sendbuf, sendcount, MPI_CXX_DOUBLE_COMPLEX, dest, sendtag,
+                      (void *)recvbuf, recvcount, MPI_CXX_DOUBLE_COMPLEX, source, recvtag,
                       comm, status);
 }
 
@@ -69,12 +69,12 @@ int MPI_Sendrecv_x(ComplexDP *sendbuf, size_t sendcount, size_t dest, size_t sen
 
 static int MPI_Bcast_x(ComplexSP *data, int root, MPI_Comm comm)
 {
-  return MPI_Bcast((void*)data, 1, MPI_COMPLEX, root, comm);
+  return MPI_Bcast((void*)data, 1, MPI_CXX_FLOAT_COMPLEX, root, comm);
 }
 
 static int MPI_Bcast_x(ComplexDP *data, int root, MPI_Comm comm)
 {
-  return MPI_Bcast((void*)data, 1, MPI_DOUBLE_COMPLEX, root, comm);
+  return MPI_Bcast((void*)data, 1, MPI_CXX_DOUBLE_COMPLEX, root, comm);
 }
 
 #else
@@ -102,8 +102,8 @@ static
                    ComplexSP *recvbuf, size_t recvcount, size_t source, size_t recvtag,
                    MPI_Comm comm, MPI_Status *status)
 {
-  return MPIX_Sendrecv_x((void *)sendbuf, sendcount, MPI_COMPLEX, dest, sendtag,
-                         (void *)recvbuf, recvcount, MPI_COMPLEX, source, recvtag,
+  return MPIX_Sendrecv_x((void *)sendbuf, sendcount, MPI_CXX_FLOAT_COMPLEX, dest, sendtag,
+                         (void *)recvbuf, recvcount, MPI_CXX_FLOAT_COMPLEX, source, recvtag,
                          comm, status);
 }
 
@@ -112,8 +112,8 @@ int MPI_Sendrecv_x(ComplexDP *sendbuf, size_t sendcount, size_t dest, size_t sen
                    ComplexDP *recvbuf, size_t recvcount, size_t source, size_t recvtag,
                    MPI_Comm comm, MPI_Status *status)
 {
-  return MPIX_Sendrecv_x((void *)sendbuf, sendcount, MPI_DOUBLE_COMPLEX, dest, sendtag,
-                         (void *)recvbuf, recvcount, MPI_DOUBLE_COMPLEX, source, recvtag,
+  return MPIX_Sendrecv_x((void *)sendbuf, sendcount, MPI_CXX_DOUBLE_COMPLEX, dest, sendtag,
+                         (void *)recvbuf, recvcount, MPI_CXX_DOUBLE_COMPLEX, source, recvtag,
                          comm, status);
 }
 

--- a/src/qureg_utils.cpp
+++ b/src/qureg_utils.cpp
@@ -658,7 +658,7 @@ void QubitRegister<Type>::dumpbin(std::string fn)
 
   double t0 = sec();
   iqs::mpi::StateBarrier();
-  MPI_File_write_at(fh, offset, (void *)(&(state[0])), size, MPI_DOUBLE_COMPLEX, &status);
+  MPI_File_write_at(fh, offset, (void *)(&(state[0])), size, MPI_CXX_DOUBLE_COMPLEX, &status);
   iqs::mpi::StateBarrier();
   double t1 = sec();
   MPI_File_close(&fh);


### PR DESCRIPTION
`MPI_COMPLEX` and `MPI_DOUBLE_COMPLEX` are Fortran MPI datatypes (3.2.2,
table 3.1). `MPI_CXX_FLOAT_COMPLEX` and `MPI_CXX_DOUBLE_COMPLEX` directly
correspond to the C++ types `std::complex<float>` and
`std::complex<double>`, respectively (table 3.4).

This should improve the portability, e.g. Open MPI's BCast breaks at
runtime with `MPI_COMPLEX` in C++.