### PR TITLE
Fix default constructor of QubitRegister

### DIFF
--- a/src/qureg_init.cpp
+++ b/src/qureg_init.cpp
@@ -35,8 +35,9 @@ QubitRegister<Type>::QubitRegister()
 
   fusion = false;
 
-  Resize(1UL);
-  state_storage[0] = {1., 0.};
+  Resize(2UL);
+  state[0] = {1., 0.};
+  state[1] = {0., 0.};
 
   if (nprocs > 1) {
     fprintf(stderr,
@@ -57,7 +58,7 @@ void QubitRegister<Type>::Resize(std::size_t new_num_amplitudes)
   log2_nprocs = iqs::ilog2(nprocs);
 
   // FIXME GG: I believe this limits the use of "resize" to adding a single qubit
-  if(GlobalSize()) assert(GlobalSize() * 2UL == new_num_amplitudes);
+  // if(GlobalSize()) assert(GlobalSize() * 2UL == new_num_amplitudes);
   num_qubits = iqs::ilog2(new_num_amplitudes);
 
   local_size_  = UL(1L << UL(num_qubits - log2_nprocs));

--- a/unit_test/include/one_qubit_register_test.hpp
+++ b/unit_test/include/one_qubit_register_test.hpp
@@ -37,6 +37,20 @@ class OneQubitRegisterTest : public ::testing::Test
 //////////////////////////////////////////////////////////////////////////////
 // Test macros:
 
+TEST_F(OneQubitRegisterTest, InitializeWithDefault)
+{
+  ComplexDP amplitude;
+
+  iqs::QubitRegister<ComplexDP> psi_0;
+  // |psi_0> = |0>
+  amplitude = psi_0.GetGlobalAmplitude(0);
+  ASSERT_DOUBLE_EQ(amplitude.real(), 1.);
+  ASSERT_DOUBLE_EQ(amplitude.imag(), 0.);
+  amplitude = psi_0.GetGlobalAmplitude(1);
+  ASSERT_DOUBLE_EQ(amplitude.real(), 0.);
+  ASSERT_DOUBLE_EQ(amplitude.imag(), 0.);
+}
+
 TEST_F(OneQubitRegisterTest, InitializeInComputationalBasis)
 {
   ComplexDP amplitude;


### PR DESCRIPTION
As I explained in Issue #91, the default constructor of `QubitRegister` was not working properly. Based on what the default constructor needs, I made the constructor allocate a length-2 `state` for a single qubit and initialize the two elements to 1.0 and 0.0. The line `if(GlobalSize()) assert(GlobalSize() * 2UL == new_num_amplitudes);` fails because `global_size_` is not initialized and can be an arbitrarily large number when using the default constructor. And since this constrains `Resize` to only adding a single additional qubit, I think this line can be deleted.

I also wrote a simple test in `unit_test/include/one_qubit_register_test.hpp` to test the behavior of the default constructor.