### PR TITLE
compile error: unit_test/include/random_number_generator_test.hpp

### DIFF
--- a/unit_test/include/random_number_generator_test.hpp
+++ b/unit_test/include/random_number_generator_test.hpp
@@ -2,7 +2,7 @@
 #define RANDOM_NUMBER_GENERATOR_TEST_HPP
 
 #include <map>
-
+#include <iomanip>	// to use: setw() in making tables
 #include "../../include/qureg.hpp"
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I'm a git beginner.
This is my first pull request.
A compile error occurred, so I tried to fix it by taking into account the corrections of other programs, so please check it.
I think the compile error is being missed with make option -j10

CXX=g++ cmake -B ./ -DIqsMPI=ON -DIqsUtest=ON -DIqsPython=ON -DIqsNoise=OFF -DBuildExamples=ON ../
:
(Omission)
:
make
:
(Omission)
:
[ 91%] Building CXX object unit_test/CMakeFiles/utest.dir/suite_of_tests.cpp.o
In file included from /xxxx/intel-qs/unit_test/suite_of_tests.cpp:40:
/xxxx/intel-qs/unit_test/include/random_number_generator_test.hpp: In member function ‘virtual void RandomNumberGeneratorTest_Visualization_Test::TestBody()’:
/xxxx/intel-qs/unit_test/include/random_number_generator_test.hpp:88:20: error: ‘setw’ was not declared in this scope; did you mean ‘getw’?
   88 |       std::cout << setw(2) << p.first << ' ' << std::string(p.second / 100, '*') << '\n';
      |                    ^~~~
      |                    getw
make[2]: *** [unit_test/CMakeFiles/utest.dir/build.make:63: unit_test/CMakeFiles/utest.dir/suite_of_tests.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:747: unit_test/CMakeFiles/utest.dir/all] Error 2