### PR TITLE
Add missing include file in intel-qs/unit_test/include/random_number_generator_test.hpp.

### DIFF
--- a/unit_test/include/random_number_generator_test.hpp
+++ b/unit_test/include/random_number_generator_test.hpp
@@ -2,6 +2,7 @@
 #define RANDOM_NUMBER_GENERATOR_TEST_HPP
 
 #include <map>
+#include <iomanip>
 
 #include "../../include/qureg.hpp"
 


### PR DESCRIPTION
Add missing #include <iomanip>.